### PR TITLE
automatic renewal of SSL certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ pids
 /docker
 
 # certificate
-/certs
+/certbot
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,16 +27,16 @@ services:
     ports:
       - '80:80'
       - '443:443'
+    restart: always
     volumes:
-      - ./logs:/var/log/nginx
-      - ./nginx.conf:/etc/nginx/nginx.conf
-      - ./certs:/etc/letsencrypt
-      - ./webroot:/var/www/certbot
+      - ./nginx.conf:/etc/nginx/nginx.conf/:ro
+      - ./certbot/www/:/etc/www/certbot/:ro
+      - ./certbot/conf/:/etc/nginx/
 
   certbot:
-    image: certbot/certbot
+    image: certbot/certbot:latest
     container_name: certbot
     volumes:
-      - ./certs:/etc/letsencrypt
-      - ./webroot:/var/www/certbot
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew --webroot -w /var/www/certbot; sleep 24h; done'"
+      - ./certbot/www/:/etc/www/certbot/:rw
+      - ./certbot/conf/:/etc/nginx/:rw
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,11 +3,6 @@ events {
 }
 
 http {
-    log_format main '$remote_addr - [$time_local] "$request" $status $body_bytes_sent';
-
-    access_log /var/log/nginx/access.log main;
-    error_log /var/log/nginx/error.log;
-
     server {
         listen 80;
         server_name quake-alert.net localhost;
@@ -25,8 +20,8 @@ http {
         listen 443 ssl;
         server_name quake-alert.net localhost;
 
-        ssl_certificate /etc/letsencrypt/live/quake-alert.net/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/quake-alert.net/privkey.pem;
+        ssl_certificate fullchain.pem;
+        ssl_certificate_key privkey.pem;
 
         location / {
             proxy_pass http://192.168.0.186:3000; # Change this to your server IP


### PR DESCRIPTION
# Description
・Added implementation to start certbot on docker and automatically update SSL certificate.

# Related issues
https://github.com/24-105/line-quake-quick-alert/issues/57

<!--
    Please provide details about feature additions, bug fixes, refactoring, etc.
-->

---

# Check List

- [x] （コンパイルエラーがない　No compilation errors）
- [x] （Nest.jsの起動エラーがない　No Nest.js startup errors）
- [x] （テストにエラーがない　No errors in tests）

---
