### PR TITLE
enable retry key

### DIFF
--- a/src/domain/useCase/http.ts
+++ b/src/domain/useCase/http.ts
@@ -1,3 +1,5 @@
+import * as crypto from 'crypto';
+
 /**
  * Create headers for the request.
  * @returns Headers object
@@ -27,5 +29,20 @@ export const createAuthHeaders = (
   return {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${channelAccessToken}`,
+  };
+};
+
+/**
+ * Create headers object with channel access token and retry key
+ * @param channelAccessToken Channel access token
+ * @returns Headers object
+ */
+export const createAuthRetryHeaders = (
+  channelAccessToken: string,
+): Record<string, string> => {
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${channelAccessToken}`,
+    'X-Line-Retry-Key': crypto.randomUUID(),
   };
 };


### PR DESCRIPTION
# Description
・Assign retry key when requesting line messaging api.
・Prevent duplicate api requests.
<!--
    Please provide details about feature additions, bug fixes, refactoring, etc.
-->

---

# Related issues

<!--
    Please let us know if there are any resolved issues.
-->

---

# Check List

- [x] （No compilation errors）
- [x] （No Nest.js startup errors）
- [x] （No errors in tests）

---
