### PR TITLE
change DynamoDB TTL to Unix epoch time

### DIFF
--- a/src/application/services/channelAccessTokenService.ts
+++ b/src/application/services/channelAccessTokenService.ts
@@ -6,6 +6,7 @@ import { ChannelAccessTokenApi } from 'src/infrastructure/api/line/channelAccess
 import { readKeyFile } from 'src/domain/useCase/file';
 import { LOG_MESSAGES } from 'src/config/logMessages';
 import { FILE_PATH } from 'src/config/constants/filePath';
+import { EXPIRATION_TIME } from 'src/config/constants/expirationTime';
 
 /**
  * Channel access token service
@@ -135,6 +136,10 @@ export class ChannelAccessTokenService implements IChannelAccessTokenService {
   private async updateChannelAccessTokens(
     jwtList: { jwt: string; iss: string }[],
   ): Promise<void> {
+    const ttl =
+      Math.floor(Date.now() / 1000) +
+      EXPIRATION_TIME.CHANNEL_ACCESS_TOKEN_VALID_TIME;
+
     for (const { jwt, iss } of jwtList) {
       try {
         const tokenResponse =
@@ -144,6 +149,7 @@ export class ChannelAccessTokenService implements IChannelAccessTokenService {
           iss,
           tokenResponse.access_token,
           tokenResponse.key_id,
+          ttl,
         );
       } catch (err) {
         this.logger.error(

--- a/src/application/services/quakeService.ts
+++ b/src/application/services/quakeService.ts
@@ -23,6 +23,7 @@ import { EncryptionService } from './encryptionService';
 import { LOG_MESSAGES } from 'src/config/logMessages';
 import Bottleneck from 'bottleneck';
 import { WebSocket } from 'ws';
+import { EXPIRATION_TIME } from 'src/config/constants/expirationTime';
 
 /**
  * Quake service
@@ -195,8 +196,10 @@ export class QuakeService {
    * @param quakeId Quake id
    */
   private async saveQuakeId(quakeId: string): Promise<void> {
+    const ttl =
+      Math.floor(Date.now() / 1000) + EXPIRATION_TIME.QUAKE_ID_VALID_TIME;
     try {
-      await this.quakeHistoryRepository.putQuakeId(quakeId);
+      await this.quakeHistoryRepository.putQuakeId(quakeId, ttl);
     } catch (err) {
       this.logger.error(
         `${LOG_MESSAGES.PUT_QUAKE_ID_FAILED}: ${quakeId}`,

--- a/src/domain/interfaces/repositories/channelAccessTokenRepository.ts
+++ b/src/domain/interfaces/repositories/channelAccessTokenRepository.ts
@@ -6,6 +6,7 @@ export interface IChannelAccessTokenRepository {
     channelId: string,
     channelAccessToken: string,
     keyId: string,
+    ttl: number,
   ): Promise<void>;
   getChannelAccessToken(channelId: string): Promise<string>;
 }

--- a/src/domain/interfaces/repositories/quakeHistoryRepository.ts
+++ b/src/domain/interfaces/repositories/quakeHistoryRepository.ts
@@ -3,5 +3,5 @@
  */
 export interface IQuakeHistoryRepository {
   isQuakeIdExists(quakeId: string): Promise<boolean>;
-  putQuakeId(quakeId: string): Promise<void>;
+  putQuakeId(quakeId: string, ttl: number): Promise<void>;
 }

--- a/src/infrastructure/repositories/channelAccessTokenRepository.ts
+++ b/src/infrastructure/repositories/channelAccessTokenRepository.ts
@@ -7,7 +7,6 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { Logger } from '@nestjs/common';
 import { IChannelAccessTokenRepository } from 'src/domain/interfaces/repositories/channelAccessTokenRepository';
 import { LOG_MESSAGES } from 'src/config/logMessages';
-import { EXPIRATION_TIME } from 'src/config/constants/expirationTime';
 import { TABLE_NAME } from 'src/config/constants/tableName';
 
 /**
@@ -47,6 +46,7 @@ export class ChannelAccessTokenRepository
     channelId: string,
     channelAccessToken: string,
     keyId: string,
+    ttl: number,
   ): Promise<void> {
     const params = {
       TableName: this.tableName,
@@ -54,7 +54,7 @@ export class ChannelAccessTokenRepository
         channelId: channelId,
         channelAccessToken: channelAccessToken,
         keyId: keyId,
-        TTL: EXPIRATION_TIME.CHANNEL_ACCESS_TOKEN_VALID_TIME,
+        TTL: ttl,
       },
     };
 

--- a/src/infrastructure/repositories/quakeHistoryRepository.ts
+++ b/src/infrastructure/repositories/quakeHistoryRepository.ts
@@ -7,7 +7,6 @@ import {
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { Logger } from '@nestjs/common';
 import { LOG_MESSAGES } from 'src/config/logMessages';
-import { EXPIRATION_TIME } from 'src/config/constants/expirationTime';
 import { TABLE_NAME } from 'src/config/constants/tableName';
 
 /**
@@ -62,12 +61,12 @@ export class QuakeHistoryRepository implements IQuakeHistoryRepository {
    * Put quake id in the table
    * @param quakeId quake id
    */
-  async putQuakeId(quakeId: string): Promise<void> {
+  async putQuakeId(quakeId: string, ttl: number): Promise<void> {
     const params = {
       TableName: this.tableName,
       Item: {
         quakeId: quakeId,
-        TTL: EXPIRATION_TIME.QUAKE_ID_VALID_TIME,
+        TTL: ttl,
       },
     };
 


### PR DESCRIPTION
# Description
This pull request introduces changes to the `ChannelAccessTokenService` and `QuakeService` to include expiration times (`ttl`) for tokens and quake IDs. Additionally, the corresponding repository interfaces and implementations have been updated to handle the new `ttl` parameter.

### Changes to ChannelAccessTokenService:

* [`src/application/services/channelAccessTokenService.ts`](diffhunk://#diff-10632440e52098359c11faaada0fadfa515e3cc5480fcd9890356ef85afa843bR9): Added `EXPIRATION_TIME` import and included `ttl` calculation and usage in `updateChannelAccessTokens` method. [[1]](diffhunk://#diff-10632440e52098359c11faaada0fadfa515e3cc5480fcd9890356ef85afa843bR9) [[2]](diffhunk://#diff-10632440e52098359c11faaada0fadfa515e3cc5480fcd9890356ef85afa843bR139-R142) [[3]](diffhunk://#diff-10632440e52098359c11faaada0fadfa515e3cc5480fcd9890356ef85afa843bR152)

### Changes to QuakeService:

* [`src/application/services/quakeService.ts`](diffhunk://#diff-95a3197eb0d22f4e80684b3663e0367840500d994bcf76b1c9874083cb813ea7R26): Added `EXPIRATION_TIME` import and included `ttl` calculation and usage in `saveQuakeId` method. [[1]](diffhunk://#diff-95a3197eb0d22f4e80684b3663e0367840500d994bcf76b1c9874083cb813ea7R26) [[2]](diffhunk://#diff-95a3197eb0d22f4e80684b3663e0367840500d994bcf76b1c9874083cb813ea7R199-R202)

### Repository Interface Updates:

* [`src/domain/interfaces/repositories/channelAccessTokenRepository.ts`](diffhunk://#diff-48c9710fbb514ea7c1ea36afc480ee85ae37024d1356d6ba1034a0a5094c27d5R9): Added `ttl` parameter to `putChannelAccessToken` method.
* [`src/domain/interfaces/repositories/quakeHistoryRepository.ts`](diffhunk://#diff-e00e60bcef99922f550f8a627776e0434ff10c054ed7f174b02e8b353c0eb790L6-R6): Added `ttl` parameter to `putQuakeId` method.

### Repository Implementation Updates:

* [`src/infrastructure/repositories/channelAccessTokenRepository.ts`](diffhunk://#diff-a2964d61aba120f11f5ef7c46e26281179491ce2a1cca22a271a173777837c0eL10): Removed `EXPIRATION_TIME` import and updated `putChannelAccessToken` method to use `ttl` parameter. [[1]](diffhunk://#diff-a2964d61aba120f11f5ef7c46e26281179491ce2a1cca22a271a173777837c0eL10) [[2]](diffhunk://#diff-a2964d61aba120f11f5ef7c46e26281179491ce2a1cca22a271a173777837c0eR49-R57)
* [`src/infrastructure/repositories/quakeHistoryRepository.ts`](diffhunk://#diff-0338921407f6f133e741b10a209f5ea66f1ab8bd248ace6c1d4b14e313ef61b7L10): Removed `EXPIRATION_TIME` import and updated `putQuakeId` method to use `ttl` parameter. [[1]](diffhunk://#diff-0338921407f6f133e741b10a209f5ea66f1ab8bd248ace6c1d4b14e313ef61b7L10) [[2]](diffhunk://#diff-0338921407f6f133e741b10a209f5ea66f1ab8bd248ace6c1d4b14e313ef61b7L65-R69)

<!--
    Please provide details about feature additions, bug fixes, refactoring, etc.
-->

---

# Related issues

<!--
    Please let us know if there are any resolved issues.
-->

---

# Check List

- [x] （No compilation errors）
- [x] （No Nest.js startup errors）
- [x] （No errors in tests）

---
