### PR TITLE
encrypt channel access token

### DIFF
--- a/src/application/services/channelAccessTokenService.ts
+++ b/src/application/services/channelAccessTokenService.ts
@@ -7,6 +7,7 @@ import { readKeyFile } from 'src/domain/useCase/file';
 import { LOG_MESSAGES } from 'src/config/logMessages';
 import { FILE_PATH } from 'src/config/constants/filePath';
 import { EXPIRATION_TIME } from 'src/config/constants/expirationTime';
+import { EncryptionService } from './encryptionService';
 
 /**
  * Channel access token service
@@ -16,6 +17,7 @@ export class ChannelAccessTokenService implements IChannelAccessTokenService {
   private readonly logger = new Logger(ChannelAccessTokenService.name);
 
   constructor(
+    private readonly encryptionService: EncryptionService,
     private readonly channelAccessTokenApi: ChannelAccessTokenApi,
     private readonly channelAccessTokenRepository: ChannelAccessTokenRepository,
   ) {}
@@ -53,7 +55,7 @@ export class ChannelAccessTokenService implements IChannelAccessTokenService {
       await this.verifyChannelAccessToken(channelAccessToken);
 
     if (isValidToken) {
-      return channelAccessToken;
+      return this.encryptionService.decrypt(channelAccessToken);
     }
 
     return this.refreshChannelAccessToken(channelIss);
@@ -65,7 +67,9 @@ export class ChannelAccessTokenService implements IChannelAccessTokenService {
    * @returns channel access token
    */
   private async getChannelAccessToken(channelIss: string): Promise<string> {
-    return this.channelAccessTokenRepository.getChannelAccessToken(channelIss);
+    const channelAccessToken =
+      await this.channelAccessTokenRepository.getChannelAccessToken(channelIss);
+    return this.encryptionService.decrypt(channelAccessToken);
   }
 
   /**
@@ -145,9 +149,13 @@ export class ChannelAccessTokenService implements IChannelAccessTokenService {
         const tokenResponse =
           await this.channelAccessTokenApi.fetchChannelAccessToken(jwt);
 
+        const encryptedAccessToken = this.encryptionService.encrypt(
+          tokenResponse.access_token,
+        );
+
         await this.channelAccessTokenRepository.putChannelAccessToken(
           iss,
-          tokenResponse.access_token,
+          encryptedAccessToken,
           tokenResponse.key_id,
           ttl,
         );

--- a/src/modules/channelAccessTokenModule.ts
+++ b/src/modules/channelAccessTokenModule.ts
@@ -4,12 +4,13 @@ import { ChannelAccessTokenBatchJob } from 'src/application/jobs/channelAccessTo
 import { ChannelAccessTokenService } from 'src/application/services/channelAccessTokenService';
 import { ChannelAccessTokenApi } from 'src/infrastructure/api/line/channelAccessTokenApi';
 import { ChannelAccessTokenRepository } from 'src/infrastructure/repositories/channelAccessTokenRepository';
+import { EncryptModule } from 'src/modules/encryptionModule';
 
 /**
  * Channel access token module
  */
 @Module({
-  imports: [HttpModule],
+  imports: [EncryptModule, HttpModule],
   providers: [
     ChannelAccessTokenBatchJob,
     ChannelAccessTokenService,

--- a/src/test/application/services/channelAccessTokenService.spec.ts
+++ b/src/test/application/services/channelAccessTokenService.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChannelAccessTokenService } from 'src/application/services/channelAccessTokenService';
+import { EncryptionService } from 'src/application/services/encryptionService';
 import { FILE_PATH } from 'src/config/constants/filePath';
+import { decrypt } from 'src/domain/useCase/encryption';
 import { readKeyFile } from 'src/domain/useCase/file';
 import { generateJwt } from 'src/domain/useCase/jwt';
 import { ChannelAccessTokenApi } from 'src/infrastructure/api/line/channelAccessTokenApi';
@@ -11,6 +13,7 @@ jest.mock('src/domain/useCase/jwt');
 
 describe('ChannelAccessTokenService', () => {
   let service: ChannelAccessTokenService;
+  let encryptionService: EncryptionService;
   let channelAccessTokenApi: ChannelAccessTokenApi;
   let channelAccessTokenRepository: ChannelAccessTokenRepository;
 
@@ -32,10 +35,18 @@ describe('ChannelAccessTokenService', () => {
             putChannelAccessToken: jest.fn(),
           },
         },
+        {
+          provide: EncryptionService,
+          useValue: {
+            encrypt: jest.fn(),
+            decrypt: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     service = module.get<ChannelAccessTokenService>(ChannelAccessTokenService);
+    encryptionService = module.get<EncryptionService>(EncryptionService);
     channelAccessTokenApi = module.get<ChannelAccessTokenApi>(
       ChannelAccessTokenApi,
     );
@@ -78,6 +89,9 @@ describe('ChannelAccessTokenService', () => {
       jest
         .spyOn(service as any, 'verifyChannelAccessToken')
         .mockResolvedValue(true);
+      jest
+        .spyOn(encryptionService, 'decrypt')
+        .mockReturnValue('decryptedToken');
 
       const result = await service.getLatestChannelAccessToken('channelIss');
 
@@ -85,7 +99,8 @@ describe('ChannelAccessTokenService', () => {
         'channelIss',
       );
       expect(service['verifyChannelAccessToken']).toHaveBeenCalledWith('token');
-      expect(result).toBe('token');
+      expect(encryptionService.decrypt).toHaveBeenCalledWith('token');
+      expect(result).toBe('decryptedToken');
     });
 
     it('should refresh the token if invalid', async () => {
@@ -117,13 +132,17 @@ describe('ChannelAccessTokenService', () => {
       jest
         .spyOn(channelAccessTokenRepository, 'getChannelAccessToken')
         .mockResolvedValue('token');
+      jest
+        .spyOn(encryptionService, 'decrypt')
+        .mockReturnValue('decryptedToken');
 
       const result = await service['getChannelAccessToken']('channelIss');
 
       expect(
         channelAccessTokenRepository.getChannelAccessToken,
       ).toHaveBeenCalledWith('channelIss');
-      expect(result).toBe('token');
+      expect(encryptionService.decrypt).toHaveBeenCalledWith('token');
+      expect(result).toBe('decryptedToken');
     });
 
     it('should verify channel access token', async () => {

--- a/src/test/application/services/userService.spec.ts
+++ b/src/test/application/services/userService.spec.ts
@@ -9,8 +9,8 @@ import { PointsScale } from 'src/domain/enum/quakeHistory/pointsEnum';
 
 describe('UserService', () => {
   let userService: UserService;
-  let userRepository: UserRepository;
   let encryptionService: EncryptionService;
+  let userRepository: UserRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({


### PR DESCRIPTION
# Description
This pull request introduces encryption and decryption functionalities to the `ChannelAccessTokenService` in order to enhance security. The changes include integrating the `EncryptionService` and updating the relevant methods to use encryption and decryption for channel access tokens.

### Enhancements to `ChannelAccessTokenService`:

* Added `EncryptionService` import and dependency injection in the constructor. [[1]](diffhunk://#diff-10632440e52098359c11faaada0fadfa515e3cc5480fcd9890356ef85afa843bR10) [[2]](diffhunk://#diff-10632440e52098359c11faaada0fadfa515e3cc5480fcd9890356ef85afa843bR20)
* Updated the `getChannelAccessToken` method to decrypt the token before returning it.
* Modified the `getLatestChannelAccessToken` method to decrypt the token if it is valid.
* Encrypted the access token before storing it in the repository.

### Module and Test Updates:

* Added `EncryptModule` to the imports in `channelAccessTokenModule.ts`.
* Updated the test file `channelAccessTokenService.spec.ts` to include `EncryptionService` and added corresponding mock implementations and assertions. [[1]](diffhunk://#diff-e71943b9e493c958250acac95791e04ae9cd3b34ab6b6170065c6419aeef78fdR3-R5) [[2]](diffhunk://#diff-e71943b9e493c958250acac95791e04ae9cd3b34ab6b6170065c6419aeef78fdR16) [[3]](diffhunk://#diff-e71943b9e493c958250acac95791e04ae9cd3b34ab6b6170065c6419aeef78fdR38-R49) [[4]](diffhunk://#diff-e71943b9e493c958250acac95791e04ae9cd3b34ab6b6170065c6419aeef78fdR92-R103) [[5]](diffhunk://#diff-e71943b9e493c958250acac95791e04ae9cd3b34ab6b6170065c6419aeef78fdR135-R145)

### Minor Refactor:

* Reordered the initialization of `userRepository` and `encryptionService` in `userService.spec.ts` for consistency.

<!--
    Please provide details about feature additions, bug fixes, refactoring, etc.
-->

---

# Related issues

<!--
    Please let us know if there are any resolved issues.
-->

---

# Check List

- [x] （No compilation errors）
- [x] （No Nest.js startup errors）
- [x] （No errors in tests）

---
